### PR TITLE
Fix JsonBuilder loop to omit trailing comma

### DIFF
--- a/src/app/vanillajavaapi/utils/JsonBuilder.java
+++ b/src/app/vanillajavaapi/utils/JsonBuilder.java
@@ -6,16 +6,15 @@ public class JsonBuilder {
 
         StringBuilder json = new StringBuilder("{");
 
-        for(int i = 0; i <= (parametros.length / 2); i += 2) {
-
+        for (int i = 0; i < parametros.length; i += 2) {
             String chave = parametros[i];
             String valor = parametros[i + 1];
 
             json.append("\"").append(chave).append("\"")
                     .append(":")
-                        .append("\"").append(valor).append("\"");
+                    .append("\"").append(valor).append("\"");
 
-            if(!(i == parametros.length / 2)) {
+            if (i + 2 < parametros.length) {
                 json.append(",");
             }
         }


### PR DESCRIPTION
## Summary
- ensure JsonBuilder iterates over parameters in pairs and only appends commas between entries

## Testing
- `javac -d out src/app/vanillajavaapi/utils/JsonBuilder.java`
- `java -cp out TestJson`

------
https://chatgpt.com/codex/tasks/task_e_689ce121d22c832b8e45d96f731cdeb0